### PR TITLE
Photo 44 db health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     command: "postgres -c 'max_connections=500'"
     volumes: 
       - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   backend: 
     build: .
     command: bin/rails s -p 3001 --binding 0.0.0.0
@@ -20,7 +25,8 @@ services:
     ports:
       - '3001:3001'
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DB_HOST: localhost
       DB_NAME: essential_photo_backend_development

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# https://stackoverflow.com/a/38732187/1935918
 set -e
 
 if [ -f /app/tmp/pids/server.pid ]; then


### PR DESCRIPTION
Added a healthcheck to the DB container using the "official" `pg_isready` command.

Followed a guide here: https://github.com/peter-evans/docker-compose-healthcheck
This did not work because user was not specified and 'root' does not exist in Postgres containers

Then made permissions fixes to the original detailed here: https://github.com/peter-evans/docker-compose-healthcheck/issues/16

No errors are seen.  Cannot confirm that this solves our issues b/c it was intermittent, but I think a functional health check ought to be good enough.